### PR TITLE
Fix issue with ember-encore used in global

### DIFF
--- a/lib/initializer.js
+++ b/lib/initializer.js
@@ -3,7 +3,6 @@ var EmberEncore = {};
 Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
     name: 'EmberEncore',
-    after: 'ember-data',
     initialize: function(container) {
       container.register('serializer:-encore', EmberEncore.Serializer);
       container.register('adapter:-encore', EmberEncore.Adapter);


### PR DESCRIPTION
When using `ember-encore` as a global, I was getting this error.

```
Uncaught Error: Assertion Failed: No application initializer named 'ember-data' 
```

As discussed with @charlesdemers, removing this line will fix the issue.
