### PR TITLE
Fix errors format to when creating a DS.InvalidError object

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -13,7 +13,7 @@ export default DS.RESTAdapter.extend(callbacks, {
 
     if (jqXHR && jqXHR.status === 422) {
       var errors = data.errors.reduce(function(memo, errorGroup) {
-        memo[errorGroup.field] = errorGroup.types[0];
+        memo[errorGroup.field] = errorGroup.types;
         return memo;
       }, {});
 


### PR DESCRIPTION
Now the API can return more than 1 error per attribute and Ember can display the messages correctly.
